### PR TITLE
[BUGFIX] Allow for newline breaks in serialized session.

### DIFF
--- a/php-unserialize.js
+++ b/php-unserialize.js
@@ -214,7 +214,7 @@ function getObject(data, offset) {
   offset = res[0];
   return [offset, {name: classname, body: res[1]}];
 };
-  
+
 
 function getClass(data, offset) {
   var res = getString(data, offset)
@@ -279,7 +279,7 @@ function unserializeSession (input) {
     }
     // Other output = $someSerializedStuff$key
     else {
-      var match = part.match(/^((?:.*?[;\}])+)([^;\}]+?)$/);
+      var match = part.match(/^((?:[\s\S]*?[;\}])+)([^;\}]+?)$/);
       if (match) {
         output[output._currKey] = unserialize(match[1]);
         output._currKey = match[2];


### PR DESCRIPTION
Your enhancements to the unserializer work great for sharing sessions between php and nodejs (classes and objects).

The only tweak I would make is within the regex.     .\*  will not match new line breaks, which caused the script to hang.  Switching it to   [\s\S]\*    solved my problem.  Hope this helps others too.
